### PR TITLE
Added ability to read TALYS model parameter limits

### DIFF
--- a/source/A0_tasman_mod.f90
+++ b/source/A0_tasman_mod.f90
@@ -729,5 +729,12 @@ module A0_tasman_mod
   integer           :: fislim       ! mass above which nuclide fissions
   integer           :: offset       ! offset for numbering or random files (TMC only)
   integer           :: tmcoffset    ! offset for starting creation of ENDF-6 files (TMC only)
+!
+!-----------------------------------------------------------------------------------------------------------------------------------
+! Variables for connecting key word ranges from TALYS
+!-----------------------------------------------------------------------------------------------------------------------------------
+!
+  character(len=132), allocatable, dimension(:,:) :: talkeyranges ! Rows -> keywords; Col1=key, Col2=lower lim, Col3=upper lim
+  logical                                         :: flaglims  ! flag to enable subroutine to set optimization limits base on TALYS
 end module A0_tasman_mod
 ! Copyright A.J. Koning 2026

--- a/source/checkkeyword.f90
+++ b/source/checkkeyword.f90
@@ -21,7 +21,7 @@ subroutine checkkeyword
 ! *** Declaration of local data
 !
   implicit none
-  integer, parameter :: numkey=141        ! number of keywords
+  integer, parameter :: numkey=142        ! number of keywords
   integer            :: i                 ! counter
   integer            :: j                 ! counter
   character(len=132) :: key               ! keyword
@@ -48,7 +48,7 @@ subroutine checkkeyword
 &   '#partvary', '#prepro', '#proconly', '#prod', '#production', '#psf', '#purr', '#readpar', '#readsens', &
 &   '#residual', '#resonance', '#runfns', '#runnubar', '#runtares', '#s20', '#s30', '#s60', '#sample', '#save', &
 &   '#searchmode', '#seed', '#score', '#sdefault', '#select', '#sens', '#sort', '#source', '#spectra', &
-&   '#tafislib', '#tafisversion', '#talexclude', '#talinclude', '#talysversion', '#taneslib', '#tanesversion', &
+&   '#tafislib', '#tafisversion', '#talexclude', '#talinclude', '#talyslims', '#talysversion', '#taneslib', '#tanesversion', &
 &   '#tareslib', '#taresversion', '#tefalversion', '#tmc', '#tmcoffset', '#tweight', '#user', '#weight', '#weightpower', &
 &   '#zaskip', '#zavary', '#zdeep', '#zmax', '#zmin'/
 !

--- a/source/fitlimits.f90
+++ b/source/fitlimits.f90
@@ -80,8 +80,10 @@ subroutine fitlimits
 ! Otherwise parameter variation is done with relative ratios.
 !
   if (flagweight) Nhistbinall = int(1.+2*Nburn**0.333333)
-  write(*,'(/" Parameter ranges for optimization"/)')
-  write(*,'(" Parameter           Input           Delta           Lower         Upper"/)')
+  if (flaglims .eqv. .false.) then
+    write(*,'(/" Parameter ranges for optimization"/)')
+    write(*,'(" Parameter           Input           Delta           Lower         Upper"/)')
+  end if
   do i = 1, Npar
     Nhistbin(i) = Nhistbinall
     if (partype(i) == 'shift ') then
@@ -109,7 +111,7 @@ subroutine fitlimits
 !     parlow(i) = max(parlow(i), 20.)
       parhigh(i) = max(parlow(i)+1, parhigh(i))
     endif
-    write(*,'(a16,5es15.6)') parkey(i),parinp(i),pardelta(i),parlow(i),parhigh(i)
+    if (flaglims .eqv. .false.) write(*,'(a16,5es15.6)') parkey(i),parinp(i),pardelta(i),parlow(i),parhigh(i)
 !
 ! Make histogram for parameter
 !
@@ -188,6 +190,14 @@ subroutine fitlimits
       endif
     endif
   enddo
+  if (flaglims) then
+    call loadtalranges
+    write(*,'(/" Parameter ranges for optimization"/)')
+    write(*,'(" Parameter           Input           Delta           Lower         Upper"/)')
+    do i=1, Npar
+      write(*,'(a16,5es15.6)') parkey(i),parinp(i),pardelta(i),parlow(i),parhigh(i)
+    end do
+  end if
   return
 end subroutine fitlimits
 ! Copyright A.J. Koning 2021

--- a/source/input2.f90
+++ b/source/input2.f90
@@ -351,6 +351,7 @@ subroutine input2
   flagglobal = .false.
   flagautoinc = .true.
   flagedep = .true.
+  flaglims = .false.
   tafislib = 'none            '
   zzmin = 1
   zzmax = numZ
@@ -466,13 +467,15 @@ subroutine input2
       cycle
     endif
     if (key == '#talysversion') then
-      read(value, '(a)' , iostat = istat) talys
+      read(value, '(a)' , iostat = istat) talysversion
       if (istat /= 0) call read_error(line, istat)
+      talys = trim(binpath)//talysversion
       cycle
     endif
     if (key == '#tefalversion') then
-      read(value, '(a)' , iostat = istat) tefal
+      read(value, '(a)' , iostat = istat) tefalversion
       if (istat /= 0) call read_error(line, istat)
+      tefal = trim(binpath)//tefalversion
       cycle
     endif
     if (key == '#taresversion') then
@@ -988,6 +991,12 @@ subroutine input2
       if (ch /= 'y' .and. ch /= 'n') call read_error(line, istat)
       cycle
     endif
+    if (key == '#talyslims') then
+      if (ch == 'n') flaglims = .false.
+      if (ch == 'y') flaglims = .true.
+      if (ch /= 'y' .and. ch /= 'n') call read_error(line, istat)
+      cycle
+    end if
     if (key == '#taneslib') then
       read(value, * , iostat = istat) taneslib
       if (istat /= 0) call read_error(line, istat)

--- a/source/inputprocess.f90
+++ b/source/inputprocess.f90
@@ -179,10 +179,8 @@ subroutine inputprocess
     if (mode >= 3) Ntalys = numtalys
   endif
   if (mode == 2) Ntalys = Npar
-  if (mode == 1) then
-    if (Nburn ==  -1) Nburn = Ntalys
-    if (Nhigh ==  -1) Nhigh = Ntalys
-  endif
+  if (Nburn ==  -1) Nburn = min(Ntalys, numtalys)
+  if (Nhigh ==  -1) Nhigh = min(Ntalys, numtalys)
   if (Ltarget /= 0 .and. Liso == 0) Liso = 1
   if (Liso == 0) isochar = ' '
   if (Liso == 1) isochar = 'm'

--- a/source/koekel.f90
+++ b/source/koekel.f90
@@ -672,6 +672,7 @@ subroutine koekelsearch(Npar, P, Pmin, Pmax, Popt, Fopt, flagwrite, flagsens, fl
               R = 2. * real(mersenne()) - 1.
             endif
             P(i) = Popt(i) + R * V(i)
+            if (P(i)<Pmin(i).or.P(i)>Pmax(i)) P(i) = Pmin(i) + real(mersenne()) * domain(i)
           enddo
           call fcn(Npar, P, F)
           if (flagwrite) call writeval(Npar, P, F, "Random  ", out)

--- a/source/loadtalranges.f90
+++ b/source/loadtalranges.f90
@@ -1,0 +1,110 @@
+subroutine loadtalranges
+  use A0_tasman_mod
+  use A1_error_handling_mod
+  ! Global variables used
+  !
+  ! talys             ! name of talys executable
+  ! parkey            ! array holding key names of parameters to be optimized
+  ! parlow            ! array holding minimum acceptable value for parameters to be optimized
+  ! parhigh           ! array holding maximum acceptable value for parameters to be optimized
+  !
+  ! Global subroutines used
+  !
+  ! read_error        ! Throw error for fileIO error and terminate program
+  ! getkeywords       ! Get key words and associated values from input file line
+
+  implicit none
+  logical            :: lexist       ! Boolean for existence of file
+  integer            :: istat        ! File IO state
+  character(len=256) :: command      ! Shell command
+  integer            :: cmdstat      ! Shell command status
+  character(len=132) :: word(40)     ! To hold key-value pairs per line in range file
+  character(len=132) :: line         ! To hold line from file temporarily
+  character(len=256) :: rangeFile    ! Path to keyword range file
+  integer            :: numkeys      ! number of keys stored in key.ranges of TALYS
+  integer            :: i            ! Iterator
+  integer            :: j            ! Iterator
+  integer            :: ix           ! String index
+
+  numkeys=0
+  i=1
+  ! Fix for now: pipe shell output to temp file to get the path to the ranges file
+  ! Only works for linux based OSes at the moment (also need access to realpath, dirname)
+  ! Based on minimal testing, should work for symlinks
+  ! Probably not safe if TASMAN is called many times from the same directory
+  command='echo $(dirname $(realpath '// talys
+  command=trim(command)//')) > temp.txt'
+  print *, "Length:", len(command), command
+  cmdstat=system(trim(command))
+  if (cmdstat/=0) then
+    write(*, '(" TASMAN-error: Unable to create temporary file with command: ", &
+    & a)') command
+    stop
+  end if
+  open(13, file='temp.txt', status='unknown', iostat=istat)
+  if (istat/=0) call read_error('temp.txt', istat)
+  read (13, '(a)') rangeFile
+  close(unit=13)
+  print *, 'range file:', rangeFile
+  cmdstat=system('rm temp.txt')
+  ix=index(rangeFile,'/bin')
+  rangeFile=trim(rangeFile(1:ix))//'misc/key.ranges'
+  if (cmdstat/=0) then
+    write(*, '(" TASMAN-error: Unable to remove temporary file with command: ", &
+    & "rm temp.txt ")') 
+    stop
+  end if
+
+  inquire(file=trim(rangeFile), exist=lexist)
+  if (lexist) then
+    open(3, file=trim(rangeFile), status='old', iostat=istat)
+    if (istat/=0) call read_error(rangeFile, istat)
+    do
+      read(3, '(a132)', iostat=istat) line
+      if (istat==-1) exit
+      if (istat/=0) call read_error(rangeFile, istat)
+      if (line(1:1)=='#') cycle
+      numkeys= numkeys + 1
+    end do
+    ! Allocate space for talkeyranges based on number of keys stored &
+    ! reopen file to obtain contents
+    close(unit=3)
+    allocate(talkeyranges(numkeys,3))
+    open(3, file=trim(rangeFile), status='old', iostat=istat)
+    do
+      read(3, '(a132)', iostat=istat) line
+      if (istat==-1) exit
+      if (line(1:1)=='#') cycle
+      call getkeywords(line, word)
+      talkeyranges(i,1)=trim(word(1))
+      talkeyranges(i,2)=trim(word(2))
+      talkeyranges(i,3)=trim(word(3))
+      i=i+1
+    end do
+    close(unit=3)
+    ! Iterate over stored key values to vary and assign ranges
+    do i=1, size(parkey)
+      do j=1, numkeys
+        if (parkey(i)==talkeyranges(j,1)) then
+          ! If no explicit value given, pass over it idk ill figure this out later maybe
+          ! As of 07/24/26, ~15 variables dont have explicit values (defined based on tal
+          ! input or A0_talys_mod `constants`)
+          if (talkeyranges(j,2)/='N/A') then
+            read(talkeyranges(j,2), *) parlow(i)
+          else
+            continue
+          end if
+          if (talkeyranges(j,3)/='N/A') then
+            read(talkeyranges(j,3), *) parhigh(i)
+          else
+            continue
+          end if
+        end if
+      end do
+    end do
+    deallocate(talkeyranges)
+    return
+  end if
+  write(*, '(" TASMAN-error: Unable to locate TALYS key word range file:", a)') trim(rangeFile)
+  stop
+end subroutine loadtalranges


### PR DESCRIPTION
I added an optional subroutine to load in TALYS model parameters (based on the TALYS fork I created) to prevent TASMAN from sampling/perturbing model parameters out of range, as discussed in [https://github.com/arjankoning1/tasman/issues/4](url).

This fix implements a safe-ish solution that doesn't require the location of the installed TALYS directory to be specified. As long as the executable (or symbolic link) is properly specified, the `loadtalranges` subroutine will determine the location on its own (based on the value of the `talysversion` key). The downside is that this method is probably not safe if you are starting multiple TASMAN runs from the same directory, although I suspect that isn't done frequently.

This subroutine is disabled by default. I added a key word '#talyslims' (with options y or n, default n) to checkkeywords.f90 and input2.f90 so that this behavior isn't automatically active.

For the few TALYS key words that have a lower or upper limit based on TALYS variables (such as memorypar or numlev), I let the existing TASMAN solution select a boundary (since I could not think of a solution within what I made for my TALYS fix).

There are also additional fixes present:

- Added a check to prevent TASMAN from perturbing a variable beyond its accepted limits if the starting temperature is 0 (koekel.f90).
- Reverted the most recent update to inputprocess.f90, since it prevents the default value assignment to Nhigh, causing TASMAN runs that dont use `mode 1` to fail if Nhigh isn't specified in the input file (inputprocess.f90)
- Changed how `talysversion` and `tefalversion` work in accordance to their specification in the provided documentation (input2.f90).

Downsides of this implementation:

- The location technique used in `loadtalranges` is currently Linux-based only since it uses shell commands. It also needs to create a temporary file to pass the output of the shell command back to TASMAN. The file is deleted before the subroutine ends, but it could be an issue if multiple TASMAN runs make/edit the same temp file at once.
- There is no way (currently) to read in the TALYS limits that are variable.

I don't expect this fix to be implemented, but I hope it may accelerate the process of getting an official TALYS-TASMAN communication fix.